### PR TITLE
properly handle byte length of unicode string terms

### DIFF
--- a/tests/test_memo.py
+++ b/tests/test_memo.py
@@ -320,11 +320,17 @@ def test_location():
                              (u'l4_lon', u'-10.677068'),
                              (u'l4_lat', u'10.062500'),
                              ])
-    
+
 
 def test_long_term():
     m = Memo()
     assert_raises(InvalidTermError, m.add_term, " " * 250)
+
+
+def test_string_normalizes_unicode():
+    stringer = Stringer.from_defaults()
+    stringer['s1'].set(u'\xc3\xb1' * 230)
+    assert_raises(InvalidTermError, getattr, stringer, '__xodb_memo__')
 
 
 class LongOne(Schema):

--- a/xodb/elements.py
+++ b/xodb/elements.py
@@ -171,8 +171,10 @@ class Schema(SparseForm):
             if element.lower:
                 term = term.lower()
             if element.prefix:
-                memo.add_term(_prefix(name, term), element.boolean, element.wdf_inc)
+                prefixed = _normalize(_prefix(name, term))
+                memo.add_term(prefixed, element.boolean, element.wdf_inc)
             else:
+                term = _normalize(term)
                 memo.add_term(term, element.boolean, element.wdf_inc)
             if element.sortable:
                 memo.add_value(name, value, type)


### PR DESCRIPTION
Although Text terms were previously normalized before being memoized, String terms were not. This patch normalizes both prefixed and unprefixed String terms and adds a test for the functionality.
