### PR TITLE
Fixes sorting of the results of expand based on newer key value structure

### DIFF
--- a/xodb/database.py
+++ b/xodb/database.py
@@ -1073,7 +1073,7 @@ class Database(object):
                 results[name] = (score, r)
             else:
                 results[name] = score
-        return OrderedDict(sorted(results.items(), key=lambda i: i[0][1], reverse=True))
+        return OrderedDict(sorted(results.items(), key=lambda i: i[1], reverse=True))
 
     @reconnector
     def estimate(self, query,


### PR DESCRIPTION
OrderedDict return from results is currently being sorted by the second letter in the term.  Whoops!
